### PR TITLE
docs: add async command and modality examples

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -43,22 +43,44 @@ from alloy import ask
 print(ask("Explain in one sentence."))
 ```
 
-## Streaming
+## Sync, async, and streaming
+
+Commands can run synchronously or asynchronously. Define an `async def`
+function to build an async command. Both sync and async commands expose
+`.async_()` for asynchronous invocation and `.stream()` for streaming
+output.
 
 ```python
-from alloy import command, ask
+from alloy import command
 
+# Sync command
 @command(output=str)
 def generate() -> str:
     return "Write a haiku about alloy."
 
-# Iterate chunks (sync). For async commands, use `async for`.
+print(generate())  # sync result
+print(await generate.async_())  # run sync command asynchronously
+
+# Async command
+@command(output=str)
+async def agen() -> str:
+    return "Write a haiku about alloy."
+
+print(await agen())  # async result
+
+# Streaming output
 for chunk in generate.stream():
     print(chunk, end="")
 
-for chunk in ask.stream("Explain briefly."):
+async for chunk in agen.stream():
     print(chunk, end="")
 ```
+
+Sync commands expose `.async_()` so they can participate in `asyncio`
+workflows, for example `await asyncio.gather(generate.async_(), agen())`.
+
+The `ask` helper mirrors these modalities via `ask()`, `await ask.async_(...)`,
+`ask.stream(...)`, and `ask.stream_async(...)`.
 
 ## Retries and error handling
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -9,6 +9,7 @@
   - Triage routing: `examples/patterns/triage_routing.py`
   - DBC tool loop: `examples/patterns/dbc_tool_loop.py`
 - Streaming: `examples/basic/streaming_outputs.py`
+- Modalities (sync/async/streaming): `examples/basic/modalities.py`
 - Dynamic system prompts: `examples/basic/dynamic_system_prompts.py`
   (These map common orchestration ideas to Alloy’s simpler primitives.)
 

--- a/examples/basic/modalities.py
+++ b/examples/basic/modalities.py
@@ -1,0 +1,45 @@
+"""Show sync commands, async commands, `.async_()`, and streaming.
+
+Run:
+  python examples/basic/modalities.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from dotenv import load_dotenv
+
+from alloy import command
+
+
+@command(output=str)
+def greet() -> str:
+    return "Say hi in one word."
+
+
+@command(output=str)
+async def greet_async() -> str:
+    return "Say hi in one word."
+
+
+async def main() -> None:
+    load_dotenv()
+
+    print("sync:", greet())
+    print("async:", await greet_async())
+    print("awaited sync via .async_():", await greet.async_())
+
+    print("sync stream:", end=" ")
+    for chunk in greet.stream():
+        print(chunk, end="", flush=True)
+    print()
+
+    print("async stream:", end=" ")
+    async for chunk in greet_async.stream():
+        print(chunk, end="", flush=True)
+    print()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- document sync, async, streaming, and `.async_()` invocation for commands
- extend modalities example with `await greet.async_()`

## Testing
- `make precommit`
- `PYTHONPATH=src ALLOY_BACKEND=fake python examples/basic_usage.py`
- `PYTHONPATH=src ALLOY_BACKEND=fake python examples/basic/modalities.py`
- `PYTHONPATH=src ALLOY_IT_MODEL=none pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f68f741008327ab10c54254d8353a