### PR TITLE
chore: remove stray debug log

### DIFF
--- a/src/alloy/models/openai.py
+++ b/src/alloy/models/openai.py
@@ -3,15 +3,12 @@ from __future__ import annotations
 from collections.abc import Iterable, AsyncIterable
 from typing import Any
 import json
-import logging
 
 from ..config import Config
 from ..errors import (
     ConfigurationError,
 )
 from .base import ModelBackend, BaseLoopState, ToolCall, ToolResult
-
-log = logging.getLogger(__name__)
 
 
 def _build_text_format(output_schema: dict | None) -> dict | None:
@@ -222,18 +219,8 @@ def _prepare_request_kwargs(
         kwargs["tools"] = tool_defs
     if text_format is not None:
         kwargs["text"] = {"format": text_format}
-    if config.temperature is not None:
-        if _is_temp_limited(config.model):
-            try:
-                log.debug(
-                    "Ignoring temperature=%s for reasoning model '%s' due to provider constraints",
-                    config.temperature,
-                    config.model,
-                )
-            except Exception:
-                pass
-        else:
-            kwargs["temperature"] = config.temperature
+    if config.temperature is not None and not _is_temp_limited(config.model):
+        kwargs["temperature"] = config.temperature
     if config.max_tokens is not None:
         kwargs["max_output_tokens"] = config.max_tokens
     return kwargs


### PR DESCRIPTION
## Summary
- remove leftover debug logging from OpenAI backend
- simplify temperature handling logic for reasoning models

## Testing
- `make precommit` *(fails: pre-commit: No such file or directory)*
- `ruff check src/alloy/models/openai.py`
- `black src/alloy/models/openai.py`
- `ALLOY_IT_MODEL=none pytest -q` *(fails: example failures; missing plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68b456b785c48327a737557178653ad4